### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:bionic
+
+# Change versions of dependencies here
+ARG EIGEN_REVISION=9e6bc1d
+ARG OPENFST_VERSION=1.7.5
+ARG PYNINI_VERSION=2.0.9
+ARG GF_VERSION=3.10-2
+
+# @Python: read files in UTF-8 encoding!
+ENV LANG=C.UTF-8
+
+# Install build environment and most dependencies via apt
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt update \
+    && apt -y install build-essential cmake git graphviz libncurses5-dev libre2-dev mercurial python-dev python3-dev python3-numpy python3-pip wget zlib1g-dev \
+    && apt -y autoremove \
+    && apt -y clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install eigen from source
+RUN hg clone https://bitbucket.org/eigen/eigen/ -r "$EIGEN_REVISION"
+RUN mkdir eigen/build
+WORKDIR eigen/build
+RUN cmake ..
+RUN make install
+WORKDIR /
+
+# Install disco-dop from source
+RUN git clone --recursive --branch=chart-exposure https://github.com/kilian-gebhardt/disco-dop
+WORKDIR disco-dop
+RUN pip3 install -r requirements.txt
+RUN make install
+WORKDIR /
+
+# Install OpenFST from source
+RUN wget "http://www.openfst.org/twiki/pub/FST/FstDownload/openfst-$OPENFST_VERSION.tar.gz"
+RUN tar -xf "openfst-$OPENFST_VERSION.tar.gz"
+WORKDIR "openfst-$OPENFST_VERSION"
+RUN ./configure --enable-bin --enable-compact-fsts --enable-compress --enable-const-fsts --enable-far --enable-linear-fsts --enable-lookahead-fsts --enable-mpdt --enable-ngram-fsts --enable-pdt --enable-python PYTHON=python3
+RUN make
+RUN make install
+WORKDIR /
+
+# Install Pynini from source
+RUN wget "http://www.openfst.org/twiki/pub/GRM/PyniniDownload/pynini-$PYNINI_VERSION.tar.gz"
+RUN tar -xf "pynini-$PYNINI_VERSION.tar.gz"
+WORKDIR "pynini-$PYNINI_VERSION"
+RUN python3 setup.py install
+WORKDIR /
+
+# Install Grammatical Framework custom package
+RUN wget "http://www.grammaticalframework.org/download/gf_${GF_VERSION}_amd64.deb"
+RUN dpkg -i "gf_${GF_VERSION}_amd64.deb"
+
+# Install Boost from source
+ARG BOOST_VERSION=1.69.0
+RUN wget "https://dl.bintray.com/boostorg/release/$BOOST_VERSION/source/boost_$(echo $BOOST_VERSION | sed 's/\./_/g').tar.gz"
+RUN tar -xf "boost_$(echo $BOOST_VERSION | sed 's/\./_/g').tar.gz"
+RUN cd "boost_$(echo $BOOST_VERSION | sed 's/\./_/g')" && ./bootstrap.sh --with-libraries= && ./b2 install || true
+
+# Build Panda parser
+ADD . /panda-parser
+WORKDIR panda-parser
+RUN pip3 install -r requirements.txt
+RUN python3 setup.py build_ext --inplace

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,15 @@
 # INSTALL GUIDE
 
+## Via Docker
+
+Build an image, the current directory is added as the top layer.
+
+`docker build --tag=panda-parser .`
+
+Obtain a shell in the container.
+
+`docker run --rm -it panda-parser bash`
+
 ## General prerequisites
 
 `python3.5` or newer, `sqlite3`, `pip3`, `re2` (`libre2-dev` on ubuntu)

--- a/parser/fst/lazy_composition.h
+++ b/parser/fst/lazy_composition.h
@@ -3,7 +3,7 @@
 
 using namespace fst;
 
-StdVectorFst construct_fa(std::vector<string> sequence, const StdFst & fst) {
+StdVectorFst construct_fa(std::vector<std::string> sequence, const StdFst & fst) {
     StdVectorFst fsa;
     fsa.SetInputSymbols(fst.InputSymbols());
     fsa.SetOutputSymbols(fst.InputSymbols());

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 backports-abc>=0.4
 Cython>=0.25.2
 graphviz>=0.5.1
+nltk>=3.4.5
 # openfst>=1.5.1.post6
 # pgf>=1.0
 pickleshare>=0.7.4

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ sterm_include = [cython_dependency_src_path]
 # change if eigen is installed in the user-local directory
 # $COMPUTE_ROOT/usr/include/eigen3,
 compute_root = ""
-eigen_include = [compute_root + "/usr/include/eigen3", compute_root + "/usr/include"]
+eigen_include = [compute_root + "/usr/include/eigen3", compute_root + "/usr/local/include/eigen3", compute_root + "/usr/include"]
 add_include = [compute_root + "/usr/local/include"]
 
 # Schick Parser (mainly implemented by Timo Schick according to construction


### PR DESCRIPTION
Adds a basic docker setup which creates an image containing the entire toolchain.
Contents of the `res` directory are not provided.

After changing the working directory it may be required to rebuild panda-parser itself.
Maybe using a volume (at least for `res`) might help?